### PR TITLE
Enable kenrel messages during bootup on the HDMI screen.

### DIFF
--- a/boot.ini.template
+++ b/boot.ini.template
@@ -27,7 +27,7 @@ setenv m_bpp "32"
 # This might break boot for some brand/models of cards.
 setenv disableuhs "disableuhs"
 
-setenv bootargs "console=ttyS0,115200n8 root=UUID=${ROOT_UUID} rootwait rw no_console_suspend vdaccfg=0xa000 logo=osd1,loaded,0x7900000,720p,full dmfc=3 cvbsmode=576cvbs hdmimode=${m} m_bpp=${m_bpp} vout=${vout_mode} ${disableuhs}"
+setenv bootargs "console=ttyS0,115200n8 console=tty0 root=UUID=${ROOT_UUID} rootwait rw no_console_suspend vdaccfg=0xa000 logo=osd1,loaded,0x7900000,720p,full dmfc=3 cvbsmode=576cvbs hdmimode=${m} m_bpp=${m_bpp} vout=${vout_mode} ${disableuhs}"
 setenv bootcmd "fatload mmc 0:1 0x21000000 uImage; fatload mmc 0:1 0x22000000 uInitrd; fatload mmc 0:1 0x21800000 meson8b_odroidc.dtb; bootm 0x21000000 0x22000000 0x21800000"
 run bootcmd
 


### PR DESCRIPTION
This patch enables the console on the HDMI display. This should also close bug

https://github.com/tomuta/debian-mini-odroid-c1/issues/15
