### PR TITLE
Adding dosfstools to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Script to build a minimal Debian sd card image.  If you are looking for a minima
 On a x86 based Ubuntu system, make sure the following packages are installed:
 ```
 sudo apt-get install build-essential wget git lzop u-boot-tools binfmt-support \
-                     qemu qemu-user-static debootstrap parted
+                     qemu qemu-user-static debootstrap parted dosfstools
 ```
 
 If you are running 64 bit Ubuntu, you might need to run the following commands to be able to launch the 32 bit toolchain:


### PR DESCRIPTION
Adding `dosfstools` to avoid `mkfs.vfat: command not found`
