### PR TITLE
Added `bc` to the list of tools to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Script to build a minimal Debian sd card image.  If you are looking for a minima
 ## Prerequisites:
 On a x86 based Ubuntu system, make sure the following packages are installed:
 ```
-sudo apt-get install build-essential wget git lzop u-boot-tools binfmt-support \
+sudo apt-get install build-essential bc wget git lzop u-boot-tools binfmt-support \
                      qemu qemu-user-static debootstrap parted
 ```
 


### PR DESCRIPTION
Apparently the Linux kernel requires `bc` to build properly. Here are a few references:

https://www.raspberrypi.org/documentation/linux/kernel/building.md
http://www.gossamer-threads.com/lists/gentoo/user/269395
