### PR TITLE
C2: Add meson timer configuration to boot.ini

### DIFF
--- a/boot-c2.ini.template
+++ b/boot-c2.ini.template
@@ -73,6 +73,13 @@ setenv hpd "true"
 # Default Console Device Setting
 setenv condev "console=ttyS0,115200n8 console=tty0"   # on both
 
+# Meson Timer
+# 1 - Meson Timer
+# 0 - Arch Timer
+# Using meson_timer improves the video playback however it breaks KVM (virtualization).
+# Using arch timer allows KVM/Virtualization to work however you'll experience poor video
+setenv mesontimer "1"
+
 ###########################################
 
 # Boot Arguments
@@ -87,5 +94,9 @@ setenv initrd_loadaddr "0x13000000"
 fatload mmc 0:1 ${initrd_loadaddr} uInitrd
 fatload mmc 0:1 ${loadaddr} Image
 fatload mmc 0:1 ${dtb_loadaddr} meson64_odroidc2.dtb
+fdt addr ${dtb_loadaddr}
+
+if test "${mesontimer}" = "0"; then fdt rm /meson_timer; fdt rm /cpus/cpu@0/timer; fdt rm /cpus/cpu@1/timer; fdt rm /cpus/cpu@2/timer; fdt rm /cpus/cpu@3/timer; fi
+if test "${mesontimer}" = "1"; then fdt rm /timer; fi
 
 booti ${loadaddr} ${initrd_loadaddr} ${dtb_loadaddr}


### PR DESCRIPTION
This fixes #42
Upstream source: https://github.com/mdrjr/c2_bootini/blob/d2b5f53c5c3e4b3df662d0e2d6428562afb9b084/boot.ini#L98_L103